### PR TITLE
Added ability to classify concepts as OA:SemanticTags

### DIFF
--- a/webapp/templates/concept-create.xhtml
+++ b/webapp/templates/concept-create.xhtml
@@ -6,6 +6,17 @@
 <head>
     <title>New Concept</title>
     <link rel="help" href="../../callimachus-for-web-developers#Concept" target="_blank" title="Help" />
+    <script type="text/javascript">
+        $(function() {
+            $('div.checkbox[data-rel]').change(function() {
+                if ($(this).find('input:checked').length) {
+                    $(this).attr("rel", $(this).attr("data-rel"));
+                } else {
+                    $(this).removeAttr("rel");
+                }
+            }).change();
+        });
+    </script>
 </head>
 <body>
     <form role="form" id="form" method="POST" action="" enctype="application/rdf+xml" typeof="skos:Concept" class="container"
@@ -43,6 +54,17 @@
                             <textarea id="example" class="form-control">{skos:example}</textarea>
                         </div>
                     </div>
+                </fieldset>
+                <fieldset class="row">
+                    <div class="form-group col-sm-6">
+                        <div class="checkbox" data-rel="rdf:type" resource="http://www.w3.org/ns/oa#SemanticTag">
+                            <label>
+                                <input type="checkbox" name="semanticTag" checked="checked" />
+                                Use as Semantic Tag
+                            </label>
+                      	</div>
+                    </div>
+                    <span rel="rdf:type" />
                 </fieldset>
                 <fieldset class="form-group">
                     <button id="create" type="submit" class="btn btn-success">Create</button>

--- a/webapp/templates/concept-edit.xhtml
+++ b/webapp/templates/concept-edit.xhtml
@@ -10,13 +10,39 @@
     <title resource="?this">{skos:prefLabel}</title>
     <link rel="help" href="../../callimachus-for-web-developers#Concept" target="_blank" title="Help" />
     <script type="text/javascript">
-        function saveChangeNote() {
-            var note = document.getElementById('note')
-            if (note.value) {
-                note.setAttribute('property', 'skos:changeNote')
-                note.setAttribute('content', note.value)
+        $(function(){
+            var oa = "http://www.w3.org/ns/oa#";
+            var label = 'div[rel="rdf:type"]';
+            $(label).each(function() {
+                if ($(this).attr('resource') !== "http://www.w3.org/ns/oa#SemanticTag") {
+                    $(this).hide();
+                }
+            });
+            $(label + '[resource="' + oa + 'SemanticTag"]').each(function(){
+                if ($(this).find('input:checked').length) {
+                    console.log('Semantic tag is checked');
+                    var other = $(this).siblings('div[resource="' + oa + 'SemanticTag"]');
+                    $(this).find('span').text(other.find('span').text());
+                    other.remove();
+                }
+            });
+            
+            $('div.checkbox').change(function(){
+                if ($(this).find('input:checked').length) {
+                    $(this).attr("rel", "rdf:type");
+                } else {
+                    $(this).removeAttr("rel");
+                }
+            });
+            
+            function saveChangeNote() {
+                var note = document.getElementById('note')
+                if (note.value) {
+                    note.setAttribute('property', 'skos:changeNote')
+                    note.setAttribute('content', note.value)
+                }
             }
-        }
+        });
     </script>
 </head>
 <body resource="?this">
@@ -67,6 +93,22 @@
                         <label for="historyNote">History</label>
                         <div>
                             <textarea id="historyNote" class="form-control">{skos:historyNote}</textarea>
+                        </div>
+                    </div>
+                </fieldset>
+                <fieldset class="row">
+                    <div class="form-group col-sm-6">
+                        <div class="checkbox" resource="http://www.w3.org/ns/oa#SemanticTag">
+                            <label>
+                                <input type="checkbox" name="semanticTag" />
+                                <span>Use as Semantic Tag</span>
+                            </label>
+                        </div>
+                        <div class="checkbox" rel="rdf:type" resource="?type">
+                            <label>
+                    			<input type="checkbox" name="type" checked="checked" />
+                				<span>{?type}</span>
+                			</label>
                         </div>
                     </div>
                 </fieldset>


### PR DESCRIPTION
Giving users the ability to control the typing of Concepts as Semantic Tags only adds benefit because it can then be used following the Open Annotation model to categorize other resources (a common use case for concepts).

The added rdf:type does not detract from other use cases or impede current functionality.
