### PR TITLE
Added code to CallimachusPolicy.addJavaPath to avoid null pointer except...

### DIFF
--- a/src/org/callimachusproject/util/CallimachusPolicy.java
+++ b/src/org/callimachusproject/util/CallimachusPolicy.java
@@ -251,9 +251,11 @@ public class CallimachusPolicy extends Policy {
 	}
 
 	private void addJavaPath(String path) {
-		if (path != null) {
+		if ((path != null) && (path.trim().length() >= 1)) {
 			File parent = new File(path).getParentFile();
-			addPath(parent.getAbsolutePath());
+            if (parent != null) {
+                addPath(parent.getAbsolutePath());
+            }
 		}
 	}
 


### PR DESCRIPTION
Added code to CallimachusPolicy.addJavaPath to avoid null pointer exceptions.  I found this necessary to run Callimachus from source under Windows 8.1 using 'ant run'.
