### PR TITLE
Fix ampersand encoding on rdfxml view

### DIFF
--- a/webapp/transforms/describe.xsl
+++ b/webapp/transforms/describe.xsl
@@ -65,7 +65,7 @@
                             if (req.readyState != 4) return;
                             if (req.status == 200 || req.status == 304) {
                                 var win = window.open('', document.URL);
-                                win.document.write('<pre>\n' + req.responseText.replace(/</g, '&lt;').replace(/>/g, '&gt;') + '\n</pre>');
+                                win.document.write('<pre>\n' + req.responseText.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') + '\n</pre>');
                             }
                         }
                         if (req.readyState == 4) return false;


### PR DESCRIPTION
When you click the RDF/XML link on a describe page it renders the XML into a `<pre>` element in a new page. If the RDF included encoded characters in the data such as &amp; and &lt; these are resolved for display in the `<pre>` element meaning that the XML is no longer valid. For example you get:
```
<page xmlns="http://xmlns.com/foaf/0.1/" rdf:resource="http://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/search.do?details=displayDetails&selectedSubstanceId=48273”/>
<literalForm xmlns="http://www.w3.org/2008/05/skos-xl#">Naphthalene, contains (flammable liquids, toxic <or> poisonous, n.o.s.)</literalForm>
```
This fix double encodes the ampersands to avoid this.