### PR TITLE
Fix #257 Graph Store Fails to Upload Files > 1024 bytes

### DIFF
--- a/src/org/callimachusproject/behaviours/DatasourceSupport.java
+++ b/src/org/callimachusproject/behaviours/DatasourceSupport.java
@@ -193,9 +193,7 @@ public abstract class DatasourceSupport extends GraphStoreSupport implements Cal
 			String[] namedGraphs, String loc, InputStream ru)
 			throws IOException, OpenRDFException {
 		BufferedInputStream bin = new BufferedInputStream(ru, MAX_RU_SIZE);
-		bin.mark(MAX_RU_SIZE);
-		int skipped = (int) bin.skip(MAX_RU_SIZE);
-		bin.reset();
+		int skipped = buffer(bin, MAX_RU_SIZE);
 		String base = loc == null ? this.getResource().stringValue() : loc;
 		final RepositoryConnection con = openConnection();
 		try {


### PR DESCRIPTION
The BufferedInputStream#skip(n) implementation would return after skipping less than n bytes if there were less than n bytes available, which can happen due to network latency. This PR replaces that usage with an implementation that keeps buffering input until n bytes are skipped, even if that blocks the thread.